### PR TITLE
Fix issue GH10 where long code lines break code blocks in Firefox.

### DIFF
--- a/_sass/elements/_code.scss
+++ b/_sass/elements/_code.scss
@@ -16,6 +16,7 @@ pre {
   line-height: $line-height-medium;
   white-space: pre-wrap;
   word-wrap: break-word;
+  word-break: break-all;
 }
 
 li code,


### PR DESCRIPTION
To prevent Firefox from expanding the view when code blocks contains long code lines and allow post/page text to overflow outside view without scroll bars, ensure code lines are broken when too long.