### PR TITLE
Remove Google Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 - [Pages](#pages)
 - [Navigation](#navigation)
 - [Disqus Comments](#disqus-comments)
-- [Google Analytics](#google-analytics)
 - [Social Media Links](#social-media-links)
 - [Update favicon](#update-favicon)
 
@@ -134,10 +133,6 @@ s.src = '//exampleone.disqus.com/embed.js';
 That's all you need to setup Disqus from the theme side. If you get any issue regarding that comments are unable to load. First, make sure you have [registered your website with Disqus (Step 1)](https://help.disqus.com/customer/portal/articles/466182-publisher-quick-start-guide)
 
 And also check [Disqus troubleshooting guide](https://help.disqus.com/customer/portal/articles/472007-i-m-receiving-the-message-%22we-were-unable-to-load-disqus-%22) if you still have issues.
-
-### Google Analytics
-
-To integrate Google Analytics, open `_includes/analytics.html`, and add your Google Analytics code.
 
 ### Social Media Links
 

--- a/_includes/analytics.html
+++ b/_includes/analytics.html
@@ -1,1 +1,0 @@
-<!-- Google Analytics Code -->

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,8 +5,6 @@
 
 <body>
 
-  {% include analytics.html %}
-
   <div class='js-off-canvas-container c-off-canvas-container'>
     {% include header.html %}
 


### PR DESCRIPTION
Would you be willing to remove this Google Analytics 'functionality' from this theme? There are better alternatives if you _must_ keep tabs on users' activity.

Some reputable alternatives can be seen here: https://switching.software/replace/google-analytics/